### PR TITLE
Change from_csv to read_csv and allow cell_axis option

### DIFF
--- a/src/wishbone/wb.py
+++ b/src/wishbone/wb.py
@@ -253,7 +253,8 @@ class SCData:
             raise RuntimeError('data_type must be either sc-seq or masscyt')
 
         # Read in csv file
-        df = pd.read_csv( counts_csv_file, sep=None, header=0, index_col= 0, engine='python' )
+        df = pd.read_csv( counts_csv_file, sep=None, header=0, index_col= 0,
+        engine='python' )
 
         if cell_axis != 0:
             df = df.transpose()

--- a/src/wishbone/wb.py
+++ b/src/wishbone/wb.py
@@ -100,7 +100,6 @@ class SCData:
         self._diffusion_map_correlations = None
         self._normalized = False
         self._cluster_assignments = None
-        self._axis = 1
 
 
         # Library size


### PR DESCRIPTION
This uses the read_csv pandas function instead of from_csv. This allows parsing of any delimiter file, also I added the cell_axis option (identical to the code in magic) so that cell column files can be used. Defaults to cell_axis =0 so example code will still run. The rest of the changes are cosmetic due to Atom removing trailing whitespaces, lines, etc.  